### PR TITLE
Add POS utilities, order models, and shift controller

### DIFF
--- a/app/Enums/PaymentMethod.php
+++ b/app/Enums/PaymentMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum PaymentMethod: string
+{
+    case Cash = 'cash';
+    case Card = 'card';
+}
+

--- a/app/Http/Controllers/Shifts/ShiftController.php
+++ b/app/Http/Controllers/Shifts/ShiftController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Shifts;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Carbon;
+
+class ShiftController extends Controller
+{
+    protected array $shift = [];
+
+    public function open(): JsonResponse
+    {
+        $this->shift = [
+            'opened_at' => Carbon::now(),
+        ];
+
+        return response()->json($this->shift);
+    }
+
+    public function close(): JsonResponse
+    {
+        $this->shift['closed_at'] = Carbon::now();
+
+        return response()->json($this->shift);
+    }
+
+    public function reportX(): JsonResponse
+    {
+        return response()->json([
+            'type' => 'X',
+            'shift' => $this->shift,
+        ]);
+    }
+
+    public function reportZ(): JsonResponse
+    {
+        return response()->json([
+            'type' => 'Z',
+            'shift' => $this->shift,
+        ]);
+    }
+}
+

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\OrderItem;
+use App\Enums\PaymentMethod;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Order extends Model
+{
+    protected $fillable = [
+        'total',
+        'payment_method',
+    ];
+
+    protected $casts = [
+        'payment_method' => PaymentMethod::class,
+    ];
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(OrderItem::class);
+    }
+}
+

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OrderItem extends Model
+{
+    protected $fillable = [
+        'order_id',
+        'product',
+        'price',
+        'quantity',
+    ];
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function subtotal(): float
+    {
+        return $this->price * $this->quantity;
+    }
+}
+

--- a/resources/js/pos/index.js
+++ b/resources/js/pos/index.js
@@ -1,0 +1,35 @@
+export class Cart {
+    constructor() {
+        this.items = [];
+    }
+
+    addItem(product, price, quantity = 1) {
+        this.items.push({ product, price, quantity });
+    }
+
+    clear() {
+        this.items = [];
+    }
+
+    get total() {
+        return this.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+    }
+}
+
+export class Invoice {
+    constructor(cart) {
+        this.cart = cart;
+        this.number = Date.now();
+        this.createdAt = new Date();
+    }
+
+    summary() {
+        return {
+            number: this.number,
+            createdAt: this.createdAt,
+            items: this.cart.items,
+            total: this.cart.total,
+        };
+    }
+}
+


### PR DESCRIPTION
## Summary
- add simple POS cart and invoice utilities
- introduce Order and OrderItem models with payment method enum
- implement ShiftController with open, close, and X/Z report endpoints

## Testing
- `composer test` *(fails: vendor/autoload.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd8af0130833298cab915e524591e