### PR TITLE
Add reporting metrics and forecasting helpers

### DIFF
--- a/app/Exports/MetricsExport.php
+++ b/app/Exports/MetricsExport.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Exports;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\FromCollection;
+
+class MetricsExport implements FromCollection
+{
+    public function __construct(private Collection $metrics)
+    {
+    }
+
+    public function collection(): Collection
+    {
+        return $this->metrics->map(fn ($value, $key) => ['metric' => $key, 'value' => $value]);
+    }
+}
+

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'total',
+    ];
+}
+

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Sale extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'total',
+    ];
+}
+

--- a/app/Services/Forecast/ForecastService.php
+++ b/app/Services/Forecast/ForecastService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services\Forecast;
+
+class ForecastService
+{
+    /**
+     * Calculate Simple Moving Average (SMA).
+     *
+     * @param array<int, float|int> $data
+     * @return array<int, float>
+     */
+    public function simpleMovingAverage(array $data, int $period): array
+    {
+        $sma = [];
+        $count = count($data);
+        if ($period <= 0 || $count < $period) {
+            return $sma;
+        }
+
+        for ($i = $period - 1; $i < $count; $i++) {
+            $window = array_slice($data, $i - $period + 1, $period);
+            $sma[] = array_sum($window) / $period;
+        }
+
+        return $sma;
+    }
+
+    /**
+     * Calculate Exponential Moving Average (EMA).
+     *
+     * @param array<int, float|int> $data
+     * @return array<int, float>
+     */
+    public function exponentialMovingAverage(array $data, int $period): array
+    {
+        $ema = [];
+        $count = count($data);
+        if ($period <= 0 || $count === 0) {
+            return $ema;
+        }
+
+        $k = 2 / ($period + 1);
+        $ema[0] = $data[0];
+        for ($i = 1; $i < $count; $i++) {
+            $ema[$i] = ($data[$i] * $k) + ($ema[$i - 1] * (1 - $k));
+        }
+
+        return $ema;
+    }
+}
+

--- a/app/Services/ReportService.php
+++ b/app/Services/ReportService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services;
+
+use App\Exports\MetricsExport;
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Facades\Excel;
+
+class ReportService
+{
+    /**
+     * Gather metrics from orders and sales.
+     */
+    public function getMetrics(): Collection
+    {
+        $totalOrders = \App\Models\Order::count();
+        $totalSales = \App\Models\Sale::sum('total');
+
+        return collect([
+            'total_orders' => $totalOrders,
+            'total_sales' => $totalSales,
+        ]);
+    }
+
+    /**
+     * Export metrics as CSV or Excel.
+     */
+    public function export(string $format = 'csv')
+    {
+        $metrics = new MetricsExport($this->getMetrics());
+        $filename = 'report.' . $format;
+
+        return Excel::download($metrics, $filename, $format);
+    }
+}
+

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "firebase/php-jwt": "^6.5",
-        "tenancy/tenancy": "^3.8"
+        "tenancy/tenancy": "^3.8",
+        "maatwebsite/excel": "^3.1"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",


### PR DESCRIPTION
## Summary
- add ReportService to gather order and sale metrics and export via maatwebsite/excel
- introduce SMA and EMA utilities for order forecasting
- stub Order and Sale models for metrics calculations

## Testing
- `composer test` *(fails: vendor missing)*
- `composer install` *(fails: required packages not in lock file / network)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd8b6bb4c83329e3381b15781152d