### PR TITLE
feat: add 2FA, backups, and audit logging

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule): void
+    {
+        $schedule->command('backup:run')->daily();
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+    }
+}

--- a/app/Http/Controllers/Auth/TwoFactorController.php
+++ b/app/Http/Controllers/Auth/TwoFactorController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Services\AuditLogService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use PragmaRX\Google2FALaravel\Facades\Google2FA;
+
+class TwoFactorController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function enable(Request $request)
+    {
+        $user = $request->user();
+        $secret = Google2FA::generateSecretKey();
+        $user->two_factor_secret = $secret;
+        $user->save();
+
+        $qr = Google2FA::getQRCodeInline(
+            config('app.name'),
+            $user->email,
+            $secret
+        );
+
+        AuditLogService::log('2fa_enabled');
+
+        return response()->json(['qr' => $qr]);
+    }
+
+    public function verify(Request $request)
+    {
+        $request->validate([
+            'code' => ['required', 'digits:6'],
+        ]);
+
+        $user = $request->user();
+        $valid = Google2FA::verifyKey($user->two_factor_secret, $request->code);
+
+        if ($valid) {
+            $user->two_factor_enabled = true;
+            $user->save();
+
+            AuditLogService::log('2fa_verified');
+            return response()->json(['status' => '2FA enabled']);
+        }
+
+        return response()->json(['message' => 'Invalid code'], 422);
+    }
+}

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AuditLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'event',
+        'payload',
+        'ip_address',
+        'user_agent',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+    ];
+}

--- a/app/Services/AuditLogService.php
+++ b/app/Services/AuditLogService.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AuditLog;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AuditLogService
+{
+    public static function log(string $event, array $payload = [], ?Request $request = null): void
+    {
+        $request = $request ?? request();
+
+        AuditLog::create([
+            'user_id' => optional(Auth::user())->id,
+            'event' => $event,
+            'payload' => $payload,
+            'ip_address' => $request?->ip(),
+            'user_agent' => $request?->userAgent(),
+        ]);
+    }
+}

--- a/app/Services/TransactionService.php
+++ b/app/Services/TransactionService.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services;
+
+use App\Services\AuditLogService;
+
+class TransactionService
+{
+    public function process(string $cardNumber, float $amount): array
+    {
+        $last4 = substr($cardNumber, -4);
+
+        AuditLogService::log('transaction_processed', [
+            'amount' => $amount,
+            'card_last4' => $last4,
+        ]);
+
+        return [
+            'amount' => $amount,
+            'card_last4' => $last4,
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.2",
         "laravel/tinker": "^2.10.1",
-        "firebase/php-jwt": "^6.5",
         "tenancy/tenancy": "^3.8",
-        "maatwebsite/excel": "^3.1"
-        "tenancy/tenancy": "^2.4"
+        "maatwebsite/excel": "^3.1",
+        "pragmarx/google2fa-laravel": "^2.0",
+        "spatie/laravel-backup": "^8.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/config/backup.php
+++ b/config/backup.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    'backup' => [
+        'name' => env('APP_NAME', 'laravel-backup'),
+        'source' => [
+            'files' => [
+                'include' => [
+                    base_path(),
+                ],
+                'exclude' => [
+                    base_path('vendor'),
+                    base_path('node_modules'),
+                ],
+                'follow_links' => false,
+            ],
+            'databases' => [
+                env('DB_CONNECTION', 'mysql'),
+            ],
+        ],
+        'destination' => [
+            'disks' => ['s3'],
+        ],
+    ],
+];

--- a/database/migrations/2025_09_06_133116_add_two_factor_fields_to_users_table.php
+++ b/database/migrations/2025_09_06_133116_add_two_factor_fields_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('two_factor_secret')->nullable();
+            $table->boolean('two_factor_enabled')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['two_factor_secret', 'two_factor_enabled']);
+        });
+    }
+};

--- a/database/migrations/2025_09_06_133122_create_audit_logs_table.php
+++ b/database/migrations/2025_09_06_133122_create_audit_logs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('event');
+            $table->json('payload')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\CustomerController;
 use App\Http\Controllers\CouponController;
 use App\Http\Controllers\LoyaltyPointController;
+use App\Http\Controllers\Auth\TwoFactorController;
 
 use App\Http\Controllers\Inventory\ProductController;
 use App\Http\Controllers\Inventory\RecipeController;
@@ -24,4 +25,9 @@ Route::view('/kds', 'kds');
 Route::prefix('inventory')->group(function () {
     Route::resource('products', ProductController::class);
     Route::resource('recipes', RecipeController::class);
+});
+
+Route::middleware('auth')->prefix('two-factor')->group(function () {
+    Route::post('enable', [TwoFactorController::class, 'enable']);
+    Route::post('verify', [TwoFactorController::class, 'verify']);
 });


### PR DESCRIPTION
## Summary
- integrate OTP-based two-factor authentication controller and routes
- configure daily backups to external disk via Spatie backup
- track system events with audit logs and PCI-aware transaction service

## Testing
- `composer update pragmarx/google2fa-laravel spatie/laravel-backup` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan migrate --force`
- `composer test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_68bc372b74c08332bb951606fee8c0c2