### PR TITLE
feat: add PWA utilities for orders

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "laravel-echo-server": "^1.7.0",
         "laravel-vite-plugin": "^2.0.0",
         "socket.io-client": "^4.7.5",
+        "qrcode": "^1.5.3",
         "tailwindcss": "^4.0.0",
         "vite": "^7.0.4"
     }

--- a/resources/js/pwa/driver-portal.js
+++ b/resources/js/pwa/driver-portal.js
@@ -1,0 +1,11 @@
+class DriverPortal extends EventTarget {
+    assign(orderId, driverId) {
+        this.dispatchEvent(new CustomEvent('assign', { detail: { orderId, driverId } }));
+    }
+
+    updateStatus(orderId, status) {
+        this.dispatchEvent(new CustomEvent('status', { detail: { orderId, status } }));
+    }
+}
+
+export const driverPortal = new DriverPortal();

--- a/resources/js/pwa/index.js
+++ b/resources/js/pwa/index.js
@@ -1,0 +1,3 @@
+export { registerServiceWorker } from './register-sw';
+export { generateMenuQR } from './qr';
+export { driverPortal } from './driver-portal';

--- a/resources/js/pwa/qr.js
+++ b/resources/js/pwa/qr.js
@@ -1,0 +1,12 @@
+import QRCode from 'qrcode';
+
+/**
+ * Generate a QR code URL for a specific table and branch.
+ * @param {string|number} tableId
+ * @param {string|number} branchId
+ * @returns {Promise<string>} Data URL representing the QR code image.
+ */
+export function generateMenuQR(tableId, branchId) {
+    const target = `/orders?table=${encodeURIComponent(tableId)}&branch=${encodeURIComponent(branchId)}`;
+    return QRCode.toDataURL(target);
+}

--- a/resources/js/pwa/register-sw.js
+++ b/resources/js/pwa/register-sw.js
@@ -1,0 +1,10 @@
+/**
+ * Register the PWA service worker.
+ */
+export function registerServiceWorker() {
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker
+            .register(new URL('./sw.js', import.meta.url), { type: 'module' })
+            .catch((error) => console.error('Service worker registration failed', error));
+    }
+}

--- a/resources/js/pwa/sw.js
+++ b/resources/js/pwa/sw.js
@@ -1,0 +1,23 @@
+self.addEventListener('install', (event) => {
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+    event.respondWith(
+        caches.open('pwa-orders').then((cache) =>
+            cache.match(event.request).then((cached) => {
+                const fetchPromise = fetch(event.request)
+                    .then((response) => {
+                        cache.put(event.request, response.clone());
+                        return response;
+                    })
+                    .catch(() => cached);
+                return cached || fetchPromise;
+            })
+        )
+    );
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js', 'resources/js/kds/app.js'],
+            input: ['resources/css/app.css', 'resources/js/app.js', 'resources/js/kds/app.js', 'resources/js/pwa/index.js'],
             refresh: true,
         }),
         tailwindcss(),


### PR DESCRIPTION
## Summary
- add PWA utilities with service worker registration
- generate QR menus for tables and branches
- introduce simple driver portal for delivery status updates

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fvite)*
- `npm run build` *(fails: vite not found)*
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc37311c108332ac0fcca591b93a97