### PR TITLE
Add menu analysis and recommendation services

### DIFF
--- a/app/Models/MenuAnalysis.php
+++ b/app/Models/MenuAnalysis.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MenuAnalysis extends Model
+{
+    protected $fillable = [
+        'product',
+        'popularity',
+        'profitability',
+        'category',
+    ];
+}

--- a/app/Services/Menu/MenuAnalysisService.php
+++ b/app/Services/Menu/MenuAnalysisService.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Services\Menu;
+
+use App\Models\MenuAnalysis;
+use App\Models\OrderItem;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class MenuAnalysisService
+{
+    /**
+     * Analyze products using a popularity/profitability matrix.
+     *
+     * @return Collection<int, MenuAnalysis>
+     */
+    public function analyze(): Collection
+    {
+        $stats = OrderItem::query()
+            ->select('product',
+                DB::raw('SUM(quantity) as popularity'),
+                DB::raw('SUM(price * quantity) as profitability'))
+            ->groupBy('product')
+            ->get();
+
+        $avgPopularity = (int) $stats->avg('popularity');
+        $avgProfitability = (float) $stats->avg('profitability');
+
+        return $stats->map(function ($row) use ($avgPopularity, $avgProfitability) {
+            $category = $this->classify(
+                (int) $row->popularity,
+                (float) $row->profitability,
+                $avgPopularity,
+                $avgProfitability
+            );
+
+            return MenuAnalysis::updateOrCreate(
+                ['product' => $row->product],
+                [
+                    'popularity' => (int) $row->popularity,
+                    'profitability' => (float) $row->profitability,
+                    'category' => $category,
+                ]
+            );
+        });
+    }
+
+    private function classify(int $popularity, float $profitability, int $avgPopularity, float $avgProfitability): string
+    {
+        if ($popularity >= $avgPopularity && $profitability >= $avgProfitability) {
+            return 'star';
+        }
+
+        if ($popularity >= $avgPopularity) {
+            return 'plowhorse';
+        }
+
+        if ($profitability >= $avgProfitability) {
+            return 'puzzle';
+        }
+
+        return 'dog';
+    }
+}

--- a/app/Services/Recommender/RecommenderService.php
+++ b/app/Services/Recommender/RecommenderService.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Services\Recommender;
+
+use App\Models\OrderItem;
+use Illuminate\Support\Facades\DB;
+
+class RecommenderService
+{
+    /**
+     * Recommend top products based on order history.
+     *
+     * @return array<int, string>
+     */
+    public function recommend(int $limit = 5): array
+    {
+        return OrderItem::query()
+            ->select('product', DB::raw('SUM(quantity) as total'))
+            ->groupBy('product')
+            ->orderByDesc('total')
+            ->limit($limit)
+            ->pluck('product')
+            ->all();
+    }
+}

--- a/database/migrations/2024_09_06_000007_create_menu_analysis_table.php
+++ b/database/migrations/2024_09_06_000007_create_menu_analysis_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('menu_analyses', function (Blueprint $table) {
+            $table->id();
+            $table->string('product')->unique();
+            $table->unsignedInteger('popularity')->default(0);
+            $table->decimal('profitability', 10, 2)->default(0);
+            $table->string('category')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('menu_analyses');
+    }
+};

--- a/database/migrations/2024_09_06_000008_create_order_items_table.php
+++ b/database/migrations/2024_09_06_000008_create_order_items_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('order_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained()->cascadeOnDelete();
+            $table->string('product');
+            $table->decimal('price', 10, 2);
+            $table->unsignedInteger('quantity');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('order_items');
+    }
+};


### PR DESCRIPTION
## Summary
- add MenuAnalysis model and migration
- implement service to classify menu items by popularity and profitability
- add simple recommender service returning top products

## Testing
- `php vendor/bin/phpunit` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3731ecac8332a5650a8e501fc09b